### PR TITLE
fix: Implement setting winewayland as graphic driver.

### DIFF
--- a/crates/omikuji-core/src/dll_packs.rs
+++ b/crates/omikuji-core/src/dll_packs.rs
@@ -222,7 +222,7 @@ fn ensure_prefix_bootstrapped(
     cmd.arg("wineboot").arg("-u");
     cmd.env_clear();
     cmd.envs(env);
-    if variant == WineVariant::ProtonGE {
+    if variant == WineVariant::Proton {
         // umu-run synchronous verb, waits for the wineboot child to exit before tearing down
         cmd.env("PROTON_VERB", "waitforexitandrun");
     }
@@ -274,7 +274,7 @@ fn set_ngx_registry(
     ]);
     cmd.env_clear();
     cmd.envs(env);
-    if variant == WineVariant::ProtonGE {
+    if variant == WineVariant::Proton {
         cmd.env("PROTON_VERB", "waitforexitandrun");
     }
     cmd.stdin(Stdio::null());

--- a/crates/omikuji-core/src/launch/mod.rs
+++ b/crates/omikuji-core/src/launch/mod.rs
@@ -20,8 +20,8 @@ pub struct LaunchConfig {
 pub enum WineVariant {
     System,
     WineGE,
-    // proton-ge needs umu-run as the launcher bin, not wine64 directly
-    ProtonGE,
+    // proton requires umu-launcher
+    Proton,
 }
 
 impl WineVariant {
@@ -29,11 +29,11 @@ impl WineVariant {
         if version.is_empty() || version == "system" {
             WineVariant::System
         } else if version.starts_with("GE-Proton") || version.starts_with("Proton") || version.starts_with("dwproton") || version.starts_with("proton") {
-            WineVariant::ProtonGE
+            WineVariant::Proton
         } else if version.starts_with("steam:") {
             let steam_version = version.strip_prefix("steam:").unwrap_or(version);
             if steam_version.starts_with("GE-Proton") || steam_version.starts_with("Proton") || steam_version.starts_with("dwproton") || steam_version.starts_with("proton") {
-                WineVariant::ProtonGE
+                WineVariant::Proton
             } else {
                 WineVariant::WineGE
             }
@@ -357,7 +357,7 @@ pub fn build_env(game: &Game, variant: WineVariant, wine_exe: &Path) -> HashMap<
     env.insert("WINEARCH".to_string(), game.wine.prefix_arch.clone());
     env.insert("WINE".to_string(), wine_exe.to_string_lossy().to_string());
 
-    if variant == WineVariant::ProtonGE {
+    if variant == WineVariant::Proton {
         let proton_path = if game.wine.version.starts_with("steam:") {
             let steam_version = game.wine.version.strip_prefix("steam:").unwrap_or(&game.wine.version);
             crate::steam::local::resolve_or_default_proton(Some(steam_version))
@@ -401,6 +401,14 @@ pub fn build_env(game: &Game, variant: WineVariant, wine_exe: &Path) -> HashMap<
 
     if game.wine.audio_driver == "alsa" {
         append_dll_override(&mut env, "winepulse.drv=d");
+    }
+
+    if game.wine.graphics_driver == "wayland" {
+        if variant == WineVariant::Proton {
+            env.insert("PROTON_ENABLE_WAYLAND".to_string(), "1".to_string());
+        } else {
+            env.insert("DISPLAY".to_string(), String::new());
+        }
     }
 
     if !game.wine.dll_overrides.is_empty() {
@@ -480,7 +488,7 @@ pub fn resolve_wine_exe(variant: WineVariant, version: &str) -> Result<PathBuf> 
                 Ok(PathBuf::from("wine"))
             }
         }
-        WineVariant::ProtonGE => {
+        WineVariant::Proton => {
             let umu_run = find_umu_run().ok_or_else(|| {
                 anyhow::anyhow!(
                     "Proton requires umu-run (umu-launcher) but it's not found. \
@@ -670,8 +678,8 @@ mod tests {
         assert_eq!(WineVariant::from_version("system"), WineVariant::System);
         assert_eq!(WineVariant::from_version("wine-ge-9-5"), WineVariant::WineGE);
         assert_eq!(WineVariant::from_version("lutris-7.2"), WineVariant::WineGE);
-        assert_eq!(WineVariant::from_version("GE-Proton10-34"), WineVariant::ProtonGE);
-        assert_eq!(WineVariant::from_version("Proton-9-0-4"), WineVariant::ProtonGE);
+        assert_eq!(WineVariant::from_version("GE-Proton10-34"), WineVariant::Proton);
+        assert_eq!(WineVariant::from_version("Proton-9-0-4"), WineVariant::Proton);
     }
 
 }

--- a/crates/omikuji-core/src/wine_tools/mod.rs
+++ b/crates/omikuji-core/src/wine_tools/mod.rs
@@ -61,7 +61,7 @@ pub fn run(game: &Game, tool: WineTool) -> Result<Child> {
     cmd.envs(&env);
 
     // proton tools (except the kill verb) need waitforexitandrun so umu-run waits for the tool to close before obliterating the prefix down
-    if variant == WineVariant::ProtonGE && !matches!(tool, WineTool::KillWineserver) {
+    if variant == WineVariant::Proton && !matches!(tool, WineTool::KillWineserver) {
         cmd.env("PROTON_VERB", "waitforexitandrun");
     }
 
@@ -89,7 +89,7 @@ fn build_command(
             vec![path.to_string_lossy().into_owned()],
         )),
         WineTool::Winetricks => {
-            if variant == WineVariant::ProtonGE {
+            if variant == WineVariant::Proton {
                 // umu-run ships its own winetricks verb apparently
                 Ok((
                     wine_exe.to_path_buf(),
@@ -101,7 +101,7 @@ fn build_command(
             }
         }
         WineTool::KillWineserver => {
-            if variant == WineVariant::ProtonGE {
+            if variant == WineVariant::Proton {
                 // wineboot -k tears down the session cleanly; invoking wineserver directly races with umu's lifecycle
                 Ok((
                     wine_exe.to_path_buf(),


### PR DESCRIPTION
Seemed to be a no-op until now. 

Also renamed the "ProtonGE" runner variant to a generic "Proton" since those won't apply to Proton-GE alone.