### PR TITLE
feat(nix): Added nix package and dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,71 @@ Or go with the AUR:
 yay -S omikuji-git
 ```
 
+
+You can also install/build it with Nix:
+
+<details>
+<summary><b>Click to expand Nix related stuff</b></summary>
+
+> For any issues related to the flake, mention @claymorwan in your issue.
+
+If you're on NixOS and using flakes, add the flake to your inputs:
+```nix
+# flake.nix
+{
+	
+	inputs = {
+		nixpkgs.url = "nixpkgs/nixos-unstable";
+		
+		omikuji = {
+			url = "github:reakjra/omikuji";
+			inputs.nixpkgs.follows = "nixpkgs";
+		};
+	};
+}
+```
+
+Then install the app:
+```nix
+{ inputs, pkgs, ... }:
+
+{
+	# NixOS side installation
+	environment.systemPackages = [
+		inputs.omikuji.packages.${pkgs.stdenv.hostPlatform.system}.default
+	];
+
+	# Or home-manager side installation
+	home.packages = [
+		inputs.omikuji.packages.${pkgs.stdenv.hostPlatform.system}.default
+	];
+}
+```
+
+To run it without installing:
+```sh
+nix run github:reakjra/omikuji
+# Add #omikuji-unwrapped to run the unwrapped package
+```
+
+Building the package itself:
+```sh
+nix build github:reakjra/omikuji
+```
+
+If you want to straight up build the app itself (during development for example), the flake also comes with a dev shell:
+```sh
+git clone https://github.com/reakjra/omikuji
+cd omikuji
+nix develop
+# Then just run the usual commands like cargo build or cargo run
+```
+
+> In almost any of these cases (apart from `nix run`) you can replace `.default` with `.omikuji-unwrapped` to refer to the unwrapped package.
+  Note that the unwrapped package isn't meant to be installed directly.
+
+</details>
+
 Runtime tools (umu-run, hpatchz, legendary, gogdl, jadeite, EGL dummy) are auto-fetched on first run.
 
 Data lives in `~/.local/share/omikuji/`.
@@ -105,3 +170,4 @@ Heavy debt to the prior art:
 - [AAG](https://github.com/an-anime-team/): gacha launcher reference. HoYo Sophon, CDN methods all from them <3. 
 
 Bundled icon set: [Material Symbols](https://github.com/google/material-design-icons) (Apache-2.0).
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778901358,
+        "narHash": "sha256-n35a8GOPs8zi35GXPe4uBz0Y8xseTkQpNgcrq81gPg0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "61ec6a4fc56fe0c2b863f7b3eaba07b6664697d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Omikuji flake";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [
+            (import inputs.rust-overlay)
+            (final: prev: {
+              omikuji = final.callPackage ./packaging/nix/package { };
+              omikuji-unwrapped = final.callPackage ./packaging/nix/package/unwrapped.nix { flakeRoot = self; };
+            })
+          ];
+          config = { };
+        };
+
+        devShells.default = import ./packaging/nix/shell.nix { inherit pkgs; };
+
+        packages = {
+          omikuji = pkgs.omikuji;
+          omikuji-unwrapped = pkgs.omikuji-unwrapped;
+          default = self'.packages.omikuji;
+        };
+      };
+    };
+}

--- a/packaging/nix/package/default.nix
+++ b/packaging/nix/package/default.nix
@@ -1,0 +1,315 @@
+{
+  lib,
+  # callPackage,
+  buildFHSEnv,
+  omikuji-unwrapped,
+  extraPkgs ? pkgs: [ ],
+  extraLibraries ? pkgs: [ ],
+  steamSupport ? false,
+}:
+
+let
+  unwrapped = omikuji-unwrapped;
+
+  qt5Deps =
+    pkgs: with pkgs.qt5; [
+      qtbase
+      qtmultimedia
+    ];
+  qt6Deps = pkgs: with pkgs.qt6; [ qtbase ];
+  gnomeDeps =
+    pkgs: with pkgs; [
+      zenity
+      gtksourceview
+      gnome-desktop
+      libgnome-keyring
+      webkitgtk_4_1
+      adwaita-icon-theme
+    ];
+  xorgDeps =
+    pkgs: with pkgs; [
+      libx11
+      libxrender
+      libxrandr
+      libxcb
+      libxmu
+      libpthread-stubs
+      libxext
+      libxdmcp
+      libxxf86vm
+      libxinerama
+      libsm
+      libxv
+      libxaw
+      libxi
+      libxcursor
+      libxcomposite
+      libxfixes
+      libxtst
+      libxscrnsaver
+      libice
+      libxt
+    ];
+  gstreamerDeps =
+    pkgs: with pkgs.gst_all_1; [
+      gstreamer
+      gst-plugins-base
+      gst-plugins-good
+      gst-plugins-ugly
+      gst-plugins-bad
+      gst-libav
+    ];
+
+in
+buildFHSEnv {
+  pname = "omikuji";
+  inherit (unwrapped) version meta;
+
+  executableName = "omikuji";
+  runScript = "omikuji";
+
+  # Many native and WINE games need 32bit
+  multiArch = true;
+
+  targetPkgs =
+    pkgs:
+    with pkgs;
+    [
+      unwrapped
+
+      # Appimages
+      fuse
+
+      # Adventure Game Studio
+      allegro
+
+      # Battle.net
+      jansson
+
+      # Curl
+      libnghttp2
+
+      # Desmume
+      lua
+      agg
+      soundtouch
+      openal
+      desktop-file-utils
+      atk
+
+      # DGen // TODO: libarchive is broken
+
+      # Dolphin
+      bluez
+      ffmpeg_6
+      gettext
+      portaudio
+      miniupnpc
+      mbedtls
+      lzo
+      sfml
+      gsm
+      wavpack
+      orc
+      nettle
+      gmp
+      pcre
+      vulkan-loader
+      zstd
+
+      # DOSBox
+      SDL_net
+      SDL_sound
+
+      # GOG
+      glib-networking
+
+      # Higan // TODO: "higan is not available for the x86_64 architecture"
+
+      # Libretro
+      fluidsynth
+      hidapi
+      libgbm
+      libdrm
+
+      # MAME
+      fontconfig
+      SDL2_ttf
+
+      # Mednafen
+      libglut
+      mesa_glu
+
+      # MESS
+      expat
+
+      # Minecraft
+      nss
+
+      # Mupen64Plus
+      boost
+      dash
+
+      # Overwatch 2
+      libunwind
+
+      # PPSSPP
+      glew
+      snappy
+
+      # Redream // "redream is not available for the x86_64 architecture"
+
+      # RPCS3
+      llvm
+      e2fsprogs
+      libgpg-error
+
+      # ScummVM
+      nasm
+      sndio
+
+      # ResidualVM is now merged with ScummVM and therefore does not exist anymore
+      flac
+
+      # Snes9x
+      libepoxy
+      minizip
+
+      # Vice
+      bison
+      flex
+
+      # WINE
+      xrandr
+      perl
+      which
+      p7zip
+      gnused
+      gnugrep
+      psmisc
+      opencl-headers
+
+      # ZDOOM
+      soundfont-fluid
+      bzip2
+      game-music-emu
+    ]
+    ++ qt5Deps pkgs
+    ++ qt6Deps pkgs
+    ++ gnomeDeps pkgs
+    ++ lib.optional steamSupport pkgs.steam
+    ++ extraPkgs pkgs;
+
+  multiPkgs =
+    pkgs:
+    with pkgs;
+    [
+      # Common
+      libsndfile
+      libtheora
+      libogg
+      libvorbis
+      libopus
+      libGLU
+      libpcap
+      libpulseaudio
+      libao
+      libevdev
+      udev
+      libgcrypt
+      libxml2
+      libusb1
+      libpng
+      libmpeg2
+      libv4l
+      libjpeg
+      libxkbcommon
+      libass
+      libcdio
+      libjack2
+      libsamplerate
+      libzip
+      libmad
+      libaio
+      libcap
+      libtiff
+      libva
+      libgphoto2
+      libxslt
+      libsndfile
+      giflib
+      zlib
+      glib
+      alsa-lib
+      zziplib
+      bash
+      dbus
+      keyutils
+      zip
+      cabextract
+      freetype
+      unzip
+      coreutils
+      readline
+      gcc
+      SDL
+      SDL2
+      curl
+      graphite2
+      gtk2
+      gtk3
+      udev
+      ncurses
+      wayland
+      libglvnd
+      vulkan-loader
+      xdg-utils
+      sqlite
+      gnutls
+      p11-kit
+      libbsd
+      harfbuzz
+
+      # PCSX2 // TODO: "libgobject-2.0.so.0: wrong ELF class: ELFCLASS64"
+
+      # WINE
+      cups
+      lcms2
+      mpg123
+      cairo
+      unixodbc
+      samba4
+      sane-backends
+      (openldap.overrideAttrs (_: {
+        doCheck = false;
+      }))
+      ocl-icd
+      util-linux
+      libkrb5
+
+      # Proton
+      libselinux
+
+      # Winetricks
+      fribidi
+      pango
+    ]
+    ++ xorgDeps pkgs
+    ++ gstreamerDeps pkgs
+    ++ extraLibraries pkgs;
+
+  extraInstallCommands = ''
+    mkdir -p $out/share
+    ln -sf ${unwrapped}/share/applications $out/share
+    ln -sf ${unwrapped}/share/icons $out/share
+  '';
+
+  # allows for some gui applications to share IPC
+  # this fixes certain issues where they don't render correctly
+  unshareIpc = false;
+
+  # Some applications such as Natron need access to MIT-SHM or other
+  # shared memory mechanisms. Unsharing the pid namespace
+  # breaks the ability for application to reference shared memory.
+  unsharePid = false;
+}

--- a/packaging/nix/package/unwrapped.nix
+++ b/packaging/nix/package/unwrapped.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  flakeRoot ? ../../../.,
+  rustPlatform,
+  fetchFromGitHub,
+  qt6,
+  pkg-config,
+  cmake,
+  protobuf,
+  makeWrapper,
+  openssl,
+  imagemagick,
+}:
+
+let
+  cargoToml = fromTOML (builtins.readFile "${flakeRoot}/crates/omikuji/Cargo.toml");
+
+  qtEnv = with qt6; env "qt-custom-${qtbase.version}" [
+    qtdeclarative
+    qtsvg
+    qtshadertools
+  ];
+in 
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "omikuji-unwrapped";
+  version = cargoToml.package.version;
+  src = flakeRoot;
+  cargoLock.lockFile = "${flakeRoot}/Cargo.lock";
+
+  nativeBuildInputs = [
+    qtEnv
+    pkg-config
+    cmake
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    protobuf
+    makeWrapper
+  ];
+
+  buildInputs = [
+    qtEnv
+    openssl
+  ]
+  ++ (with qt6; [
+      qtbase
+      qtdeclarative
+      qtsvg
+      qtshadertools
+    ]);
+
+  doCheck = false;
+
+  prePatch = ''
+    substituteInPlace ./crates/omikuji/build.rs \
+      --replace-fail '"/usr/lib/qt6/bin/qsb"' '"${qtEnv}/bin/qsb"'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Add Qt-related environment variables.
+    # https://discourse.nixos.org/t/python-qt-woes/11808/10
+    setQtEnvironment=$(mktemp)
+    random=$(openssl rand -base64 20 | sed "s/[^a-zA-Z0-9]//g")
+    makeWrapper "$(type -p sh)" "$setQtEnvironment" "''${qtWrapperArgs[@]}" --argv0 "$random"
+    sed "/$random/d" -i "$setQtEnvironment"
+    source "$setQtEnvironment"
+    export QMAKE="${qtEnv}/bin/qmake"
+
+    cargo build --release
+
+    runHook postHook
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 target/release/omikuji $out/bin/omikuji
+
+    install -Dm444 $src/packaging/io.github.reakjra.omikuji.desktop.in \
+      $out/share/applications/io.github.reakjra.omikuji.desktop
+
+
+    install -Dm444 \
+      $src/crates/omikuji/qml/icons/app.png \
+      $out/share/icons/hicolor/512x512/apps/io.github.reakjra.omikuji.png
+
+    for size in 16 24 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      ${lib.getExe imagemagick} \
+        $src/crates/omikuji/qml/icons/app.png \
+        -resize "$size"x"$size" \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/io.github.reakjra.omikuji.png
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Qt/QML based game launcher for Linux";
+    homepage = "https://github.com/reakjra/omikuji";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ claymorwan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "omikuji";
+  };
+})

--- a/packaging/nix/shell.nix
+++ b/packaging/nix/shell.nix
@@ -1,0 +1,52 @@
+# Shell made by https://github.com/Thra11, and sligthly modified
+
+{ pkgs ? import <nixpkgs> { } }:
+let
+  rustVersion = "latest";
+  # rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
+  #   extensions = [
+  #     "rust-src" # for rust-analyzer
+  #   ];
+  # };
+  qtEnv = with pkgs.qt6; env "qt-custom-${qtbase.version}" [
+    qtdeclarative
+    qtsvg
+  ];
+in
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    qtEnv
+    makeWrapper
+    pkg-config
+    cmake
+    protobuf
+  ] ++ (with rust-bin.stable.${rustVersion}.default; [
+    rustc
+    cargo
+    rustfmt
+    rust-analyzer
+    clippy
+  ]);
+
+  buildInputs = with pkgs; [
+    rust-bin.stable.${rustVersion}.default
+    # rust-analyzer
+    udev
+    libglvnd
+    pkg-config
+    qtEnv
+    openssl
+  ];
+
+  RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+  shellHook = ''
+    # Add Qt-related environment variables.
+    # https://discourse.nixos.org/t/python-qt-woes/11808/10
+    setQtEnvironment=$(mktemp)
+    random=$(openssl rand -base64 20 | sed "s/[^a-zA-Z0-9]//g")
+    makeWrapper "$(type -p sh)" "$setQtEnvironment" "''${qtWrapperArgs[@]}" --argv0 "$random"
+    sed "/$random/d" -i "$setQtEnvironment"
+    source "$setQtEnvironment"
+    export QMAKE="${qtEnv}/bin/qmake"
+  '';
+}


### PR DESCRIPTION
This PR adds a nix flake including a package for omikuji and a dev shell.

To be exact it comes with 2 packges:
- and unwrapped package which is basically just the apps package
- a normal package which wrap the previous one in a FHS environment.

This is actually the same way other launchers like lutris and heroic are packaged in the nixpkgs (I'm using a modified version of the lutris FHS envrionment).

It took me a long while to get the app packaged correctly and did a bunch of testing to make sure things work. I've also added a section in the README to explain how to install it, and pointed out to ping me in any flake related issues since this is kinda my responsability now lol

In the future I plan to add a home-manager module for reproducible config, but I gotta finish working on it first lol