### PR TITLE
fix(nix): add missing qt5compat to qtEnv and buildInputs

### DIFF
--- a/packaging/nix/package/unwrapped.nix
+++ b/packaging/nix/package/unwrapped.nix
@@ -18,7 +18,8 @@ let
   qtEnv = with qt6; env "qt-custom-${qtbase.version}" [
     qtdeclarative
     qtsvg
-    qtshadertools
+    qtshadertools 
+    qt5compat
   ];
 in 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -45,7 +46,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       qtbase
       qtdeclarative
       qtsvg
-      qtshadertools
+      qtshadertools 
+      qt5compat
     ]);
 
   doCheck = false;


### PR DESCRIPTION
SvgIcon.qml imports Qt5Compat.GraphicalEffects, but qt5compat was not included in the qtEnv or buildInputs in unwrapped.nix.

This causes the application to crash on startup with:
  module "Qt5Compat.GraphicalEffects" is not installed

Adding qt5compat to qtEnv ensures wrapQtAppsHook includes it in QML2_IMPORT_PATH at runtime. 

omikuji
QQmlApplicationEngine failed to load component
qrc:/qt/qml/omikuji/qml/Main.qml:490:5: Type NavTabs unavailable
qrc:/qt/qml/omikuji/qml/components/navigation/NavTabs.qml:180:21: Type SvgIcon unavailable
qrc:/qt/qml/omikuji/qml/components/widgets/SvgIcon.qml:2:1: module "Qt5Compat.GraphicalEffects" is not installed
qt.qpa.services: Failed to register with host portal QDBusError("org.freedesktop.portal.Error.Failed", "Could not register app ID: App info not found for 'omikuji'")