### PR TITLE
feat(nix): home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ Then install the app:
 { inputs, pkgs, ... }:
 
 {
-	# NixOS side installation
+  # Using the home-manager module (recommended)
+  programs.omikuji.enable = true;
+
+	# Or NixOS side installation
 	environment.systemPackages = [
 		inputs.omikuji.packages.${pkgs.stdenv.hostPlatform.system}.default
 	];
@@ -142,6 +145,7 @@ If someone willingly wants to take charge for `.deb` / `.rpm` / Flatpak / etc. p
 
 ## Documentation
 - [Configuration](docs/configuration.md): `settings.toml`, custom runners, DLL packs
+- [Nix Home Manager options](docs/hm-module.md): Every options available in the Home Manager module
 
 ## Contributing
 

--- a/docs/hm-module.md
+++ b/docs/hm-module.md
@@ -1,0 +1,128 @@
+# Omikuji Home Manager Module Options
+
+
+## [`programs.omikuji.enable`](#L20)
+
+Whether to enable omikuji.
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`programs.omikuji.extraPackages`](#L23)
+
+
+List of packages to pass as extraPkgs to lutris.
+Please note runners are not detected properly this way, use a proper option for those.
+
+
+**Type:** `with types; listOf package`
+
+**Default:** `[ ]`
+
+**Example:** `"with pkgs; [mangohud winetricks gamescope gamemode umu-launcher]"`
+
+## [`programs.omikuji.steamPackage`](#L33)
+
+
+This must be the same you use for your system, or two instances will conflict,
+for example, if you configure steam through the nixos module, a good value is "osConfig.programs.steam.package"
+
+
+**Type:** `with types; nullOr package`
+
+**Default:** `null`
+
+**Example:** `"pkgs.steam or osConfig.programs.steam.package"`
+
+## [`programs.omikuji.winePackages`](#L43)
+
+
+List of wine packages to be added for omikuji to use.
+
+
+**Type:** `with types; listOf package`
+
+**Default:** `[ ]`
+
+**Example:** `"[ pkgs.wineWow64Packages.full ]"`
+
+## [`programs.omikuji.protonPackages`](#L52)
+
+
+List of proton packages to be added for omikuji to use with umu-launcher.
+
+
+**Type:** `with types; listOf package`
+
+**Default:** `[ ]`
+
+**Example:** `"[ pkgs.proton-ge-bin ]"`
+
+## [`programs.omikuji.defaultWinePackage`](#L61)
+
+
+Default wine/proton package used in the settings.
+
+
+**Type:** `with types; nullOr package`
+
+**Default:** `null`
+
+**Example:** `"pkgs.proton-ge-bin"`
+
+## [`programs.omikuji.settings.defaults`](#L71)
+
+
+Configuration written to
+`$XDG_DATA_HOME/omikuji/defaults.toml`.
+
+
+**Type:** `any`
+
+**Default:** `{ }`
+
+**Example:**
+
+```nix
+wine = {
+  ntsync = true
+  dxvk = true
+  vkd3d = true
+  d3d_extras = true
+};
+
+launch.env = {
+  PROTON_USE_WAYLAND = "1";
+};
+
+graphics.mangohud = true;
+system.gamemode = true;
+```
+
+## [`programs.omikuji.settings.settings`](#L95)
+
+
+Configuration written to
+`$XDG_DATA_HOME/omikuji/settings.toml`.
+
+
+**Type:** `any`
+
+**Default:** `{ }`
+
+## [`programs.omikuji.settings.ui`](#L104)
+
+
+Configuration written to
+`$XDG_DATA_HOME/omikuji/ui.toml`.
+
+
+**Type:** `any`
+
+**Default:** `{ }`
+
+---
+*Generated with [nix-doc](https://github.com/Thunderbottom/nix-doc)*

--- a/flake.nix
+++ b/flake.nix
@@ -35,5 +35,10 @@
           default = self'.packages.omikuji;
         };
       };
+
+      flake.homeModules = {
+        omikuji = import ./packaging/nix/module.nix self;
+        default = self.homeModules.omikuji;
+      };
     };
 }

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -1,0 +1,167 @@
+self:
+{ lib, pkgs, config, ... }:
+
+let
+  inherit (lib)
+  mkOption
+  mkEnableOption
+  mkPackageOption
+  types
+  mkIf
+  optional
+  literalExpression
+  ;
+
+  cfg = config.programs.omikuji;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.omikuji = {
+    enable = mkEnableOption "omikuji";
+    package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "omikuji" { nullable = true; };
+
+    extraPackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = "with pkgs; [mangohud winetricks gamescope gamemode umu-launcher]";
+      description = ''
+        List of packages to pass as extraPkgs to lutris.
+        Please note runners are not detected properly this way, use a proper option for those.
+      '';
+    };
+
+    steamPackage = mkOption {
+      type = with types; nullOr package;
+      default = null;
+      example = "pkgs.steam or osConfig.programs.steam.package";
+      description = ''
+        This must be the same you use for your system, or two instances will conflict,
+        for example, if you configure steam through the nixos module, a good value is "osConfig.programs.steam.package"
+      '';
+    };
+
+    winePackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = "[ pkgs.wineWow64Packages.full ]";
+      description = ''
+        List of wine packages to be added for omikuji to use.
+      '';
+    };
+
+    protonPackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = "[ pkgs.proton-ge-bin ]";
+      description = ''
+        List of proton packages to be added for omikuji to use with umu-launcher.
+      '';
+    };
+
+    defaultWinePackage = mkOption {
+      type = with types; nullOr package;
+      default = null;
+      example = "pkgs.proton-ge-bin";
+      description = ''
+        Default wine/proton package used in the settings.
+      '';
+    };
+
+    settings = {
+      defaults = mkOption {
+        inherit (tomlFormat) type;
+        default = { };
+        example = literalExpression ''
+          wine = {
+            ntsync = true
+            dxvk = true
+            vkd3d = true
+            d3d_extras = true
+          };
+
+          launch.env = {
+            PROTON_USE_WAYLAND = "1";
+          };
+
+          graphics.mangohud = true;
+          system.gamemode = true;
+        '';
+        description = ''
+          Configuration written to
+          {file}`$XDG_DATA_HOME/omikuji/defaults.toml`.
+        '';
+      };
+
+      settings = mkOption {
+        inherit (tomlFormat) type;
+        default = { };
+        description = ''
+          Configuration written to
+          {file}`$XDG_DATA_HOME/omikuji/settings.toml`.
+        '';
+      };
+
+      ui = mkOption {
+        inherit (tomlFormat) type;
+        default = { };
+        description = ''
+          Configuration written to
+          {file}`$XDG_DATA_HOME/omikuji/ui.toml`.
+        '';
+      };
+    };
+  };
+
+  config = let
+    formatWineName = (package: lib.toLower package.name);
+  in
+  mkIf cfg.enable
+  {
+    home.packages = mkIf (cfg.package != null) [
+      (cfg.package.override {
+        extraPkgs = (_prev: cfg.extraPackages ++ (optional (cfg.steamPackage != null) cfg.steamPackage));
+      })
+    ];
+
+    xdg.dataFile =
+    let
+      buildWineLink =
+        packages:
+        map (
+          # lutris seems to not detect wine/proton if the name has some caps
+          package:
+          (lib.nameValuePair "omikuji/runners/${formatWineName package}" {
+            source = package;
+          })
+        ) packages;
+
+      protonPackages = map (proton: proton.steamcompattool)
+          (cfg.protonPackages ++ (lib.lists.optionals (cfg.defaultWinePackage != null) [ cfg.defaultWinePackage.steamcompattool ]));
+    
+      defaultSettingsMerged = lib.recursiveUpdate
+        (lib.optionalAttrs (cfg.settings.defaults != { }) cfg.settings.defaults)
+        (lib.optionalAttrs (cfg.defaultWinePackage != null) {
+          wine.version = formatWineName cfg.defaultWinePackage;
+        })
+        ;
+    in
+    {
+      "omikuji/defaults.toml" = mkIf (defaultSettingsMerged != { }) {
+        source = (tomlFormat.generate "omikuji-config-defaults" defaultSettingsMerged);
+      };
+
+      "omikuji/settings.toml" = mkIf (cfg.settings.settings != { }) {
+        source = (tomlFormat.generate "omikuji-config-defaults" cfg.settings.settings);
+      };
+
+      "omikuji/ui.toml" = mkIf (cfg.settings.ui != { }) {
+        source = (tomlFormat.generate "omikuji-config-defaults" cfg.settings.ui);
+      };
+    }
+    // lib.listToAttrs (
+        buildWineLink cfg.winePackages
+        ++ buildWineLink protonPackages
+        );
+  };
+}
+

--- a/packaging/nix/package/default.nix
+++ b/packaging/nix/package/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  # callPackage,
   buildFHSEnv,
   omikuji-unwrapped,
   extraPkgs ? pkgs: [ ],

--- a/packaging/nix/package/unwrapped.nix
+++ b/packaging/nix/package/unwrapped.nix
@@ -14,12 +14,15 @@
 
 let
   cargoToml = fromTOML (builtins.readFile "${flakeRoot}/crates/omikuji/Cargo.toml");
-
-  qtEnv = with qt6; env "qt-custom-${qtbase.version}" [
+  qtDeps = with qt6; [
+    qtbase
     qtdeclarative
     qtsvg
     qtshadertools
+    qt5compat
   ];
+
+  qtEnv = with qt6; env "qt-custom-${qtbase.version}" qtDeps;
 in 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "omikuji-unwrapped";
@@ -41,12 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     qtEnv
     openssl
   ]
-  ++ (with qt6; [
-      qtbase
-      qtdeclarative
-      qtsvg
-      qtshadertools
-    ]);
+  ++ qtDeps;
 
   doCheck = false;
 
@@ -55,9 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"/usr/lib/qt6/bin/qsb"' '"${qtEnv}/bin/qsb"'
   '';
 
-  buildPhase = ''
-    runHook preBuild
-
+  preBuild = ''
     # Add Qt-related environment variables.
     # https://discourse.nixos.org/t/python-qt-woes/11808/10
     setQtEnvironment=$(mktemp)
@@ -66,17 +62,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     sed "/$random/d" -i "$setQtEnvironment"
     source "$setQtEnvironment"
     export QMAKE="${qtEnv}/bin/qmake"
-
-    cargo build --release
-
-    runHook postHook
   '';
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 target/release/omikuji $out/bin/omikuji
-
+  postInstall = ''
     install -Dm444 $src/packaging/io.github.reakjra.omikuji.desktop.in \
       $out/share/applications/io.github.reakjra.omikuji.desktop
 
@@ -92,8 +80,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
         -resize "$size"x"$size" \
         $out/share/icons/hicolor/"$size"x"$size"/apps/io.github.reakjra.omikuji.png
     done
-
-    runHook postInstall
   '';
 
   meta = {

--- a/packaging/nix/shell.nix
+++ b/packaging/nix/shell.nix
@@ -9,8 +9,11 @@ let
   #   ];
   # };
   qtEnv = with pkgs.qt6; env "qt-custom-${qtbase.version}" [
+    qtbase
     qtdeclarative
     qtsvg
+    qtshadertools
+    qt5compat
   ];
 in
 pkgs.mkShell {


### PR DESCRIPTION
This PR adds a Home Manager module, every option available is documented in docs/hm-module.md

Basically , there's the usual options to enable the module and use a different package than the default, 2 options that allows installing wine and proton packages from nix packages (installed in `$XDG_DATA_HOME/omikuji/runners`, and some options to configure the app reproducibly (supporting `defaults.toml`, `settings.toml` and `ui.toml`, tho I would recommend usually only reproducibly configure `defaults.toml`) 

I also refactored the unwrapped package a bit and also added `qt6.qt5compat` the its dependencies to fix the issue mentioned in #42.
Tested everything and it seems to work fine