### PR TITLE
feat(nix): Cachix binary cache and actions

### DIFF
--- a/.github/workflows/cachix-build.yml
+++ b/.github/workflows/cachix-build.yml
@@ -1,0 +1,27 @@
+name: Cachix build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  omikuji-unwrapped:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v16
+        with:
+          name: omikuji
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Update flake inputs
+        run: nix flake update
+      
+      - name: Build omikuji-unwrapped
+        run: nix build .#omikuji-unwrapped
+        
+      - run: nix run .#omikuji-unwrapped -- --version

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you don't want to compile the full package, there's a cachix binary cache fro
     ];
 
     trusted-public-keys = [
-      "omikuji.cachix.org-1:5vrRCU3F6e9sDXggp0oqCNCXMWEN3EQSIbIDx8DPfec="
+      "omikuji.cachix.org-1:dS6sbpMxarHWIIk3y0R7KXz3eVHUg1lo/y3gMbv4JhM="
     ];
 
   };

--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ Then install the app:
 }
 ```
 
+If you don't want to compile the full package, there's a cachix binary cache from where you can pull the precompiled package:
+```nix
+{
+  nix.settings = {
+    substituters = [
+      "https://omikuji.cachix.org"
+    ];
+      
+    trusted-substituters = [
+      "https://omikuji.cachix.org"
+    ];
+
+    trusted-public-keys = [
+      "omikuji.cachix.org-1:5vrRCU3F6e9sDXggp0oqCNCXMWEN3EQSIbIDx8DPfec="
+    ];
+
+  };
+}
+```
+And restart the nix daemon to apply them, then you can install the package
+> More info about substituter [here](https://wiki.nixos.org/wiki/Binary_Cache#Using_a_binary_cache)
+
 To run it without installing:
 ```sh
 nix run github:reakjra/omikuji

--- a/packaging/nix/package/default.nix
+++ b/packaging/nix/package/default.nix
@@ -1,3 +1,5 @@
+# Modified version of the wrapped lutris package from the nixpkgs
+
 {
   lib,
   buildFHSEnv,
@@ -279,9 +281,7 @@ buildFHSEnv {
       unixodbc
       samba4
       sane-backends
-      (openldap.overrideAttrs (_: {
-        doCheck = false;
-      }))
+      openldap
       ocl-icd
       util-linux
       libkrb5


### PR DESCRIPTION
This PR adds a cachix binary cache for omikuji.
Basically, it's a github action that builds the package and then pushes it to a binary cache. Nix user can add it to their nix config to download that prebuilt package instead of building it (which is pretty useful knowing how long it takes to build omikuji lol)
The action runs everytime time there's a pull request merged, every commit to the master branch and also can be triggered manually

Tho in order to be able to push the package to the binary cache, we need to add a secret to the repo called `CACHIX_AUTH_TOKEN`, which is a token with read and write permission from the binary cache.
We have 2 options:
- u create a cachix binary cache called `omikuji`, then create a token for it and add it as a secret in the repo. Making the binary cache is really easy to do thankfully
- or we can just use my binary cache that i made to make this PR

First option would prolly be preferable tho since u're the only maintainer of the repo that can manage secrets