### PR TITLE
fix(nix): fix mismatched derivation hash

### DIFF
--- a/.github/workflows/cachix-build.yml
+++ b/.github/workflows/cachix-build.yml
@@ -10,16 +10,13 @@ jobs:
   omikuji-unwrapped:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v16
+      - uses: cachix/cachix-action@v17
         with:
           name: omikuji
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - name: Update flake inputs
-        run: nix flake update
-      
       - name: Build omikuji-unwrapped
         run: nix build .#omikuji-unwrapped
         


### PR DESCRIPTION
Fixes the derivation's hashes mismatch caused by the flake inputs update job, now it should be working correctly from what I've tested