### PR TITLE
fix(nix): running appimages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-l57y2CK9dTSChgb6Edg7kkXu5DA4rucVbNFoQHUBjmw=",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "lastModified": 1784356753,
+        "narHash": "sha256-zupdTm41be2fY8cexroEOGjopl3F2Gqs3gk7ieqaM3s=",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1026231.65179426c83b/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1036777.61b7c44c4073/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783058364,
-        "narHash": "sha256-felUcVUtcdI15evRNkVfLq3opwceShhbrJt6hDlZvrk=",
+        "lastModified": 1784438913,
+        "narHash": "sha256-NYF7ZM5ip0u+w1pBFDpIGEbrbgN/wpnLFAmBkWkYMXw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e7a078c7feb51f37955a832b22a96de5fccb1f7a",
+        "rev": "afacd6819d3765a05814ee8e3de74c77d42ac799",
         "type": "github"
       },
       "original": {

--- a/packaging/nix/package/unwrapped.nix
+++ b/packaging/nix/package/unwrapped.nix
@@ -2,7 +2,6 @@
   lib,
   flakeRoot ? ../../../.,
   rustPlatform,
-  fetchFromGitHub,
   qt6,
   pkg-config,
   cmake,
@@ -48,6 +47,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doCheck = false;
 
+  # Needed for omikuji to be able to run appimages
+  qtWrapperArgs = [
+    "--prefix APPIMAGE_EXTRACT_AND_RUN : 1"
+  ];  
+  
   prePatch = ''
     substituteInPlace ./crates/omikuji/build.rs \
       --replace-fail '"/usr/lib/qt6/bin/qsb"' '"${qtEnv}/bin/qsb"'


### PR DESCRIPTION
Fixes omikuji not being able to run appimages on NixOS
This apparently cause cuz I didn't add an env called `APPIMAGE_EXTRACT_AND_RUN` which, u guessed it, makes it so the appimage gets extracted to be ran like they usually are on NixOS

Also updated flake lockfile