### PR TITLE
refactor(nix): rename `ui` related options to `apps`

### DIFF
--- a/docs/hm-module.md
+++ b/docs/hm-module.md
@@ -1,7 +1,8 @@
-# Home Manager Module Options
+# NixOS Module Options
 
 
-## [`programs.omikuji.enable`](#L20)
+<a id="options-programs-omikuji-enable"></a>
+## [`options.programs.omikuji.enable`](module.nix#L36)
 
 Whether to enable omikuji.
 
@@ -11,79 +12,95 @@ Whether to enable omikuji.
 
 **Example:** `true`
 
-## [`programs.omikuji.extraPackages`](#L23)
+<a id="options-programs-omikuji-package"></a>
+## [`options.programs.omikuji.package`](module.nix#L37)
+
+The omikuji package to use.
+
+**Type:** `package`
+
+**Default:** `pkgs.omikuji`
+
+<a id="options-programs-omikuji-extraPackages"></a>
+## [`options.programs.omikuji.extraPackages`](module.nix#L39)
 
 
 List of packages to pass as extraPkgs to lutris.
 Please note runners are not detected properly this way, use a proper option for those.
 
 
-**Type:** `with types; listOf package`
+**Type:** `list of package`
 
 **Default:** `[ ]`
 
 **Example:** `"with pkgs; [mangohud winetricks gamescope gamemode umu-launcher]"`
 
-## [`programs.omikuji.steamPackage`](#L33)
+<a id="options-programs-omikuji-steamPackage"></a>
+## [`options.programs.omikuji.steamPackage`](module.nix#L49)
 
 
 This must be the same you use for your system, or two instances will conflict,
 for example, if you configure steam through the nixos module, a good value is "osConfig.programs.steam.package"
 
 
-**Type:** `with types; nullOr package`
+**Type:** `null or package`
 
 **Default:** `null`
 
 **Example:** `"pkgs.steam or osConfig.programs.steam.package"`
 
-## [`programs.omikuji.winePackages`](#L43)
+<a id="options-programs-omikuji-winePackages"></a>
+## [`options.programs.omikuji.winePackages`](module.nix#L59)
 
 
 List of wine packages to be added for omikuji to use.
 
 
-**Type:** `with types; listOf package`
+**Type:** `list of package`
 
 **Default:** `[ ]`
 
 **Example:** `"[ pkgs.wineWow64Packages.full ]"`
 
-## [`programs.omikuji.protonPackages`](#L52)
+<a id="options-programs-omikuji-protonPackages"></a>
+## [`options.programs.omikuji.protonPackages`](module.nix#L68)
 
 
 List of proton packages to be added for omikuji to use with umu-launcher.
 
 
-**Type:** `with types; listOf package`
+**Type:** `list of package`
 
 **Default:** `[ ]`
 
 **Example:** `"[ pkgs.proton-ge-bin ]"`
 
-## [`programs.omikuji.defaultWinePackage`](#L61)
+<a id="options-programs-omikuji-defaultWinePackage"></a>
+## [`options.programs.omikuji.defaultWinePackage`](module.nix#L77)
 
 
 Default wine/proton package used in the settings.
 
 
-**Type:** `with types; nullOr package`
+**Type:** `null or package`
 
 **Default:** `null`
 
 **Example:** `"pkgs.proton-ge-bin"`
 
-## [`programs.omikuji.settings.mutableDefaults`](#L72)
+<a id="options-programs-omikuji-settings-mutableDefaults"></a>
+## [`options.programs.omikuji.settings.mutableDefaults`](module.nix#L88)
 
 
 Wether configuration in `defaults.toml` can be updated by omikuji.
 
 
-**Type:** `types.bool`
+**Type:** `boolean`
 
 **Default:** `true`
 
-## [`programs.omikuji.settings.defaults`](#L80)
+<a id="options-programs-omikuji-settings-defaults"></a>
+## [`options.programs.omikuji.settings.defaults`](module.nix#L96)
 
 
 Configuration written to
@@ -112,17 +129,19 @@ graphics.mangohud = true;
 system.gamemode = true;
 ```
 
-## [`programs.omikuji.settings.mutableSettings`](#L104)
+<a id="options-programs-omikuji-settings-mutableSettings"></a>
+## [`options.programs.omikuji.settings.mutableSettings`](module.nix#L120)
 
 
 Wether configuration in `settings.toml` can be updated by omikuji.
 
 
-**Type:** `types.bool`
+**Type:** `boolean`
 
 **Default:** `true`
 
-## [`programs.omikuji.settings.settings`](#L112)
+<a id="options-programs-omikuji-settings-settings"></a>
+## [`options.programs.omikuji.settings.settings`](module.nix#L128)
 
 
 Configuration written to
@@ -164,17 +183,19 @@ dll_packs = [
 ];
 ```
 
-## [`programs.omikuji.settings.mutableUi`](#L149)
+<a id="options-programs-omikuji-settings-mutableApps"></a>
+## [`options.programs.omikuji.settings.mutableApps`](module.nix#L165)
 
 
 Wether configuration in `app.toml` can be updated by omikuji.
 
 
-**Type:** `types.bool`
+**Type:** `boolean`
 
 **Default:** `true`
 
-## [`programs.omikuji.settings.ui`](#L157)
+<a id="options-programs-omikuji-settings-apps"></a>
+## [`options.programs.omikuji.settings.apps`](module.nix#L173)
 
 
 Configuration written to
@@ -208,5 +229,21 @@ console_mode = {
 };
 ```
 
+<a id="options-programs-omikuji-settings-ui"></a>
+## [`options.programs.omikuji.settings.ui`](module.nix#L25)
+
+> [!WARNING]
+> This option was renamed. Use [`programs.omikuji.settings.apps`](#options-programs-omikuji-settings-apps) instead.
+
+**Type:** `renamed option`
+
+<a id="options-programs-omikuji-settings-mutableUi"></a>
+## [`options.programs.omikuji.settings.mutableUi`](module.nix#L29)
+
+> [!WARNING]
+> This option was renamed. Use [`programs.omikuji.settings.mutableApps`](#options-programs-omikuji-settings-mutableApps) instead.
+
+**Type:** `renamed option`
+
 ---
-*Generated with [nix-doc](https://github.com/Thunderbottom/nix-doc)*
+*Generated with [nix-options-doc](https://github.com/Thunderbottom/nix-options-doc)*

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -1,5 +1,10 @@
 self:
-{ lib, pkgs, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 
 let
   inherit (lib)
@@ -16,6 +21,17 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "omikuji" "settings" "ui" ]
+      [ "programs" "omikuji" "settings" "apps" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "programs" "omikuji" "settings" "mutableUi" ]
+      [ "programs" "omikuji" "settings" "mutableApps" ]
+    )
+  ];
+  
   options.programs.omikuji = {
     enable = mkEnableOption "omikuji";
     package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "omikuji" { nullable = true; };
@@ -146,7 +162,7 @@ in
         '';
       };
 
-      mutableUi = mkOption {
+      mutableApps = mkOption {
         type = types.bool;
         default = true;
         description = ''
@@ -154,7 +170,7 @@ in
         '';
       };
 
-      ui = mkOption {
+      apps = mkOption {
         inherit (tomlFormat) type;
         default = { };
         example = literalExpression ''
@@ -211,7 +227,7 @@ in
 
     defaultsToml = tomlFormat.generate "omikuji-config-defaults" defaultSettingsMerged;
     settingsToml = tomlFormat.generate "omikuji-config-settings" cfg.settings.settings;
-    uiToml = tomlFormat.generate "omikuji-config-ui" cfg.settings.ui;
+    appsToml = tomlFormat.generate "omikuji-config-apps" cfg.settings.apps;
   in
   mkIf cfg.enable
   {
@@ -226,7 +242,7 @@ in
         # Generating settings
         omikujiDefaultsSettings = mkIf (defaultSettingsMerged != { } && cfg.settings.mutableDefaults) (impureConfigActivation "${config.xdg.dataHome}/omikuji/defaults.toml" defaultsToml);
         omikujiSettingsSettings = mkIf (cfg.settings.settings != { } && cfg.settings.mutableSettings) (impureConfigActivation "${config.xdg.dataHome}/omikuji/settings.toml" settingsToml);
-        omikujiUiSettings = mkIf (cfg.settings.ui != { } && cfg.settings.mutableUi) (impureConfigActivation "${config.xdg.dataHome}/omikuji/app.toml" uiToml);
+        omikujiAppsSettings = mkIf (cfg.settings.apps != { } && cfg.settings.mutableApps) (impureConfigActivation "${config.xdg.dataHome}/omikuji/app.toml" appsToml);
       };
     };
 
@@ -254,8 +270,8 @@ in
         source = settingsToml;
       };
 
-      "omikuji/app.toml" = mkIf (cfg.settings.ui != { } && !cfg.settings.mutableUi) {
-        source = uiToml;
+      "omikuji/app.toml" = mkIf (cfg.settings.apps != { } && !cfg.settings.mutableApps) {
+        source = appsToml;
       };
     }
     // lib.listToAttrs (


### PR DESCRIPTION
Renames every opption related to to the new "apps" name